### PR TITLE
Allow redirects to external websites

### DIFF
--- a/src/Redirects.php
+++ b/src/Redirects.php
@@ -5,7 +5,7 @@ namespace Truecast;
  *
  * @package General
  * @author Daniel Baldwin
- * @version 1.0.0
+ * @version 1.0.1
  */
 class Redirects
 {
@@ -46,6 +46,11 @@ class Redirects
 			$redirect = $redirectList[$requestUri];
 		} else {
 			foreach ($redirectList as $key=>$value) {
+				# check whether an internal redirect has a forward slash at the front and if not, add it
+				if(substr($value, 0, 1) !== "/" && substr($value, 0, 7) !== "http://" && substr($value, 0, 8) !== "https://") {
+					$value = "/" . $value;
+				}
+				
 				$match = strstr($key, '*', true);
 				if ($match !== false) {
 					$strLen = strlen($match);

--- a/src/Redirects.php
+++ b/src/Redirects.php
@@ -75,7 +75,7 @@ class Redirects
 		}
 
 		header("HTTP/1.1 $header"); 
-		header("Location: /$redirect");
+		header("Location: $redirect");
 		exit;
 	}
 }


### PR DESCRIPTION
Removing a forward slash at the location header will allow you to specify external domains (e.g. https://example.org/) in the JSON file. However, with this change there would be no backwards compatibility with the master (original), considering that then a redirects.json file has to be modified to have the redirect value start with a forward slash (/).
To combat this I added a section which would check if it's an internal redirect without a forward slash at the beginning, and if so it will add a / at the beginning.